### PR TITLE
Revert "Fallback to a2dp if no profile is set"

### DIFF
--- a/handler/qpulseaudioengine.h
+++ b/handler/qpulseaudioengine.h
@@ -95,7 +95,6 @@ private:
     std::string m_nametoset, m_valuetoset;
     std::string m_defaultsink, m_defaultsource;
     std::string m_bt_hsp, m_bt_hsp_a2dp;
-    std::string m_default_bt_card_fallback;
     std::string m_voicecallcard, m_voicecallhighest, m_voicecallprofile;
 
     bool handleOperation(pa_operation *operation, const char *func_name);


### PR DESCRIPTION
This is not an actual revert. It tries to remove a change that's not
been merged into telepathy-ofono but is somehow appeared in this repo.

This interferes with PA's profile switching to headset_head_unit when
using HFP via oFono. Because oFono's transport acquire is (apparently)
asynchronous, PA will set the profile to off while waiting for it. If
we intervene and set the profile to a2dp_sink, we'll cause a quick
profile switch in succession and confuse A2DP transport's state (which
is a PA bug that's still reproducible on bionic at least).

See https://bazaar.launchpad.net/~tiagosh/telepathy-ofono/fallback_a2dp/revision/172