### PR TITLE
cmake: drop the cruft

### DIFF
--- a/approver/CMakeLists.txt
+++ b/approver/CMakeLists.txt
@@ -31,7 +31,7 @@ configure_file(org.freedesktop.Telepathy.Client.TelephonyServiceApprover.service
 install(TARGETS telephony-service-approver RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.freedesktop.Telepathy.Client.TelephonyServiceApprover.service DESTINATION share/dbus-1/services)
 install(FILES TelephonyServiceApprover.client DESTINATION share/telepathy/clients)
-install(FILES 50-com.canonical.TelephonyServiceApprover.pkla DESTINATION "${CMAKE_INSTALL_LOCALSTATEDIR}/lib/polkit-1/localauthority/10-vendor.d")
+install(FILES 50-com.canonical.TelephonyServiceApprover.pkla DESTINATION "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/lib/polkit-1/localauthority/10-vendor.d")
 install(FILES com.canonical.TelephonyServiceApprover.policy DESTINATION share/polkit-1/actions)
 install(FILES com.canonical.TelephonyServiceApprover.xml DESTINATION share/dbus-1/interfaces)
 

--- a/debian/rules
+++ b/debian/rules
@@ -17,15 +17,11 @@ override_dh_install:
 	dh $@ --parallel --with translations
 
 override_dh_auto_configure:
-	# Debian defines CMAKE_INSTALL_LOCALSTATEDIR as /usr/var, which is wrong.
-	# So until Debian bug 719148 is fixed, do it ourselves.
 ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH), $(qmltestskip_architectures)))
 	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Debug \
-	                     -DSKIP_QML_TESTS="on" \
-	                     -DCMAKE_INSTALL_LOCALSTATEDIR="/var"
+	                     -DSKIP_QML_TESTS="on"
 else
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Debug \
-	                     -DCMAKE_INSTALL_LOCALSTATEDIR="/var"
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Debug
 endif
 
 override_dh_auto_test:


### PR DESCRIPTION
Use the FULL_LOCALSTATEDIR instead of the LOCALSTATEDIR, LOCALSTATEDIR
would return as a var instead of the /var, which would make it install
things in PREFIX/var (/usr/var), use FULL_LOCALSTATEDIR instead which
does right thing.

https://cmake.org/cmake/help/v3.4/module/GNUInstallDirs.html