### PR TITLE
use sent message date as timestamp reference

### DIFF
--- a/indicator/textchannelobserver.cpp
+++ b/indicator/textchannelobserver.cpp
@@ -350,7 +350,7 @@ void TextChannelObserver::showNotificationForFlashMessage(const Tp::ReceivedMess
     NotificationData *data = new NotificationData();
     data->senderId = contact->id();
     data->accountId = accountId;
-    data->timestamp = message.received();
+    data->timestamp = message.sent();
     data->messageText = message.text();
     data->encodedEventId = token.toHex();
 
@@ -536,7 +536,7 @@ void TextChannelObserver::showNotificationForMessage(const Tp::TextChannelPtr ch
     messagingMenuData.participantIds = participantIds;
     messagingMenuData.accountId = accountId;
     messagingMenuData.encodedEventId = token.toHex();
-    messagingMenuData.timestamp = message.received();
+    messagingMenuData.timestamp = message.sent();
     messagingMenuData.messageText = messageText;
     messagingMenuData.targetId = channel->targetId();
     messagingMenuData.targetType = channel->targetHandleType();

--- a/tests/common/mock/textchannel.cpp
+++ b/tests/common/mock/textchannel.cpp
@@ -193,7 +193,8 @@ void MockTextChannel::messageReceived(const QString &message, const QVariantMap 
 
     Tp::MessagePart header;
     header["message-token"] = QDBusVariant(info["SentTime"].toString() +"-" + QString::number(mMessageCounter++));
-    header["message-received"] = QDBusVariant(QDateTime::fromString(info["SentTime"].toString(), Qt::ISODate).toTime_t());
+    header["message-received"] = QDBusVariant(QDateTime::currentDateTime().toTime_t());
+    header["message-sent"] = QDBusVariant(QDateTime::fromString(info["SentTime"].toString(), Qt::ISODate).toTime_t());
     header["message-sender"] = QDBusVariant(mTargetHandle);
     header["message-sender-id"] = QDBusVariant(mRecipients.first());
     header["message-type"] = QDBusVariant(Tp::ChannelTextMessageTypeNormal);
@@ -212,6 +213,7 @@ void MockTextChannel::mmsReceived(const QString &id, const QVariantMap &properti
     header["message-token"] = QDBusVariant(id);
     header["message-sender"] = QDBusVariant(mTargetHandle);
     header["message-received"] = QDBusVariant(QDateTime::fromString(properties["Date"].toString(), Qt::ISODate).toTime_t());
+    header["message-sent"] = QDBusVariant(QDateTime::fromString(properties["SentTime"].toString(), Qt::ISODate).toTime_t());
     header["message-type"] = QDBusVariant(Tp::DeliveryStatusDelivered);
     if (!subject.isEmpty())
     {


### PR DESCRIPTION
Following https://github.com/ubports/messaging-app/issues/179 : Use message sent datetime as a reference for the indicator

Note that PR  https://github.com/ubports/telepathy-ofono/pull/14 need to be merged before to fix issues with Pinephone having null sent date: 