### PR TITLE
Fix channel incoming logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,65 +1,7 @@
-pipeline {
-  agent any
-  stages {
-    stage('Build source') {
-      steps {
-        sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-      }
-    }
-    stage('Build binary - armhf') {
-      steps {
-        parallel(
-          "Build binary - armhf": {
-            node(label: 'arm64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="armhf"
-build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
+@Library('ubports-build-tools') _
 
+buildAndProvideDebianPackage()
 
-          },
-          "Build binary - arm64": {
-            node(label: 'arm64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="arm64"
-    build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
-          },
-          "Build binary - amd64": {
-            node(label: 'amd64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="amd64"
-    build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
-          }
-        )
-      }
-    }
-    stage('Results') {
-      steps {
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-        unstash 'build-armhf'
-        unstash 'build-arm64'
-        unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
-        sh '''/usr/bin/build-repo.sh'''
-      }
-    }
-    stage('Cleanup') {
-      steps {
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-      }
-    }
-  }
-}
+// Or if the package consists entirely of arch-independent packages:
+// (optiional optimization, will confuse BlueOcean's live view at build stage)
+// buildAndProvideDebianPackage(/* isArchIndependent */ true)

--- a/handler/handler.cpp
+++ b/handler/handler.cpp
@@ -168,13 +168,14 @@ void Handler::onCallChannelReady(Tp::PendingOperation *op)
     // if the call is neither Accepted nor Active, it means it got dispatched directly to the handler without passing
     // through any approver. For phone calls, this would mean calls getting auto-accepted which is not desirable
     // so we return an error here
-    bool incoming = !callChannel->isRequested();
+    bool incoming;
     AccountEntry *accountEntry = TelepathyHelper::instance()->accountForConnection(callChannel->connection());
-    if (accountEntry &&
-        !callChannel->initiatorContact().isNull() &&
-        callChannel->initiatorContact() != accountEntry->account()->connection()->selfContact()) {
-        incoming = true;
+    if (accountEntry && !callChannel->initiatorContact().isNull()) {
+        incoming = callChannel->initiatorContact() != accountEntry->account()->connection()->selfContact();
+    } else {
+        incoming = !callChannel->isRequested();
     }
+
     if (incoming && callChannel->callState() != Tp::CallStateAccepted && callChannel->callState() != Tp::CallStateActive) {
         qWarning() << "Available channel was not approved by telephony-service-approver, ignoring it.";
         if (context) {

--- a/libtelephonyservice/callentry.cpp
+++ b/libtelephonyservice/callentry.cpp
@@ -269,12 +269,12 @@ bool CallEntry::dialing() const
 
 bool CallEntry::incoming() const
 {
-    bool isIncoming = !mChannel->isRequested();
+    bool isIncoming;
 
-    if (mAccount &&
-        !mChannel->initiatorContact().isNull() &&
-        mChannel->initiatorContact() != mAccount->account()->connection()->selfContact()) {
-        isIncoming = true;
+    if (mAccount && !mChannel->initiatorContact().isNull()) {
+        isIncoming = mChannel->initiatorContact() != mAccount->account()->connection()->selfContact();
+    } else {
+        isIncoming = !mChannel->isRequested();
     }
 
     return isIncoming;


### PR DESCRIPTION
If an oFono call is triggered outside of Telepathy control (e.g. by a
Bluetooth handset requesting a redial directly to oFono), the
"requested" property will be always false. The old logic will then
wrongly assumes that the call is incoming because of this.

Turns out, the "initiatorContact" property seems to be more reliable in
this regard, so use it whenever possible. The approver part already uses
this logic, so I think it's safe to use it in the rest of the code.

The git/bzr history seems to suggest that this has something to do with
supporting SIP. However, currently SIP support is not available. If we
develop it, we may want to look at this.