### PR TITLE
Failed MMS redownload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,11 +70,11 @@ pkg_check_modules(TPFS REQUIRED telepathy-farstream)
 pkg_check_modules(GST REQUIRED gstreamer-1.0)
 pkg_check_modules(FS REQUIRED farstream-0.2)
 pkg_check_modules(PULSEAUDIO libpulse)
+pkg_check_modules(HISTORY REQUIRED history-service)
 
 if (WANT_UI_SERVICES)
     pkg_check_modules(MESSAGING_MENU REQUIRED messaging-menu)
     pkg_check_modules(UserMetrics REQUIRED libusermetricsinput-1)
-    pkg_check_modules(HISTORY REQUIRED history-service)
     pkg_check_modules(URL_DISPATCHER REQUIRED url-dispatcher-1)
 
     add_definitions(-DWANT_UI_SERVICES)

--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -34,6 +34,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/libtelephonyservice
     ${CMAKE_CURRENT_BINARY_DIR}
     ${PULSEAUDIO_INCLUDE_DIRS}
+    ${HISTORY_INCLUDE_DIRS}
     )
 
 add_executable(telephony-service-handler ${handler_SRCS} ${handler_HDRS})
@@ -43,6 +44,7 @@ target_link_libraries(telephony-service-handler
     ${TP_QT5_FS_LIBRARIES}
     ${TPFS_LIBRARIES}
     ${FS_LIBRARIES}
+    ${HISTORY_LIBRARIES}
     telephonyservice
     ${PULSEAUDIO_LIBRARIES}
     Qt5::Contacts

--- a/handler/Handler.xml
+++ b/handler/Handler.xml
@@ -74,8 +74,9 @@
             <dox:d><![CDATA[
                 Request message to be redownloaded
             ]]></dox:d>
-            <arg name="properties" type="a{sv}" direction="in"/>
-            <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+            <arg name="accountId" type="s" direction="in"/>
+            <arg name="threadId" type="s" direction="in"/>
+            <arg name="eventId" type="s" direction="in"/>
         </method>
         <method name="DestroyTextChannel">
             <dox:d><![CDATA[

--- a/handler/Handler.xml
+++ b/handler/Handler.xml
@@ -70,6 +70,13 @@
             <arg name="properties" type="a{sv}" direction="in"/>
             <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
         </method>
+        <method name="RedownloadMessage">
+            <dox:d><![CDATA[
+                Request message to be redownloaded
+            ]]></dox:d>
+            <arg name="properties" type="a{sv}" direction="in"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+        </method>
         <method name="DestroyTextChannel">
             <dox:d><![CDATA[
                 Destroy a text channel. Only works on channels that have the

--- a/handler/handlerdbus.cpp
+++ b/handler/handlerdbus.cpp
@@ -208,7 +208,14 @@ QString HandlerDBus::StartChat(const QString &accountId, const QVariantMap &prop
 
 void HandlerDBus::AcknowledgeAllMessages(const QVariantMap &properties)
 {
+    qDebug() << "jezek - HandlerDBus::AcknowledgeAllMessages";
     TextHandler::instance()->acknowledgeAllMessages(properties);
+}
+
+void HandlerDBus::RedownloadMessage(const QVariantMap &properties)
+{
+    qDebug() << "jezek - HandlerDBus::RedownloadMessage";
+    TextHandler::instance()->redownloadMessage(properties);
 }
 
 void HandlerDBus::StartCall(const QString &number, const QString &accountId)

--- a/handler/handlerdbus.cpp
+++ b/handler/handlerdbus.cpp
@@ -208,13 +208,11 @@ QString HandlerDBus::StartChat(const QString &accountId, const QVariantMap &prop
 
 void HandlerDBus::AcknowledgeAllMessages(const QVariantMap &properties)
 {
-    qDebug() << "jezek - HandlerDBus::AcknowledgeAllMessages";
     TextHandler::instance()->acknowledgeAllMessages(properties);
 }
 
 void HandlerDBus::RedownloadMessage(const QString &accountId, const QString &threadId, const QString &eventId)
 {
-    qDebug() << "jezek - HandlerDBus::RedownloadMessage";
     TextHandler::instance()->redownloadMessage(accountId, threadId, eventId);
 }
 

--- a/handler/handlerdbus.cpp
+++ b/handler/handlerdbus.cpp
@@ -212,10 +212,10 @@ void HandlerDBus::AcknowledgeAllMessages(const QVariantMap &properties)
     TextHandler::instance()->acknowledgeAllMessages(properties);
 }
 
-void HandlerDBus::RedownloadMessage(const QVariantMap &properties)
+void HandlerDBus::RedownloadMessage(const QString &accountId, const QString &threadId, const QString &eventId)
 {
     qDebug() << "jezek - HandlerDBus::RedownloadMessage";
-    TextHandler::instance()->redownloadMessage(properties);
+    TextHandler::instance()->redownloadMessage(accountId, threadId, eventId);
 }
 
 void HandlerDBus::StartCall(const QString &number, const QString &accountId)

--- a/handler/handlerdbus.h
+++ b/handler/handlerdbus.h
@@ -79,7 +79,7 @@ public Q_SLOTS:
     Q_NOREPLY void AcknowledgeMessages(const QVariantList &messages);
     QString StartChat(const QString &accountId, const QVariantMap &properties);
     Q_NOREPLY void AcknowledgeAllMessages(const QVariantMap &properties);
-    Q_NOREPLY void RedownloadMessage(const QVariantMap &properties);
+    Q_NOREPLY void RedownloadMessage(const QString &accountId, const QString &threadId, const QString &eventId);
     bool DestroyTextChannel(const QString &objectPath);
     bool ChangeRoomTitle(const QString &objectPath, const QString &title);
     Q_NOREPLY void InviteParticipants(const QString &objectPath, const QStringList &participants, const QString &message);

--- a/handler/handlerdbus.h
+++ b/handler/handlerdbus.h
@@ -79,6 +79,7 @@ public Q_SLOTS:
     Q_NOREPLY void AcknowledgeMessages(const QVariantList &messages);
     QString StartChat(const QString &accountId, const QVariantMap &properties);
     Q_NOREPLY void AcknowledgeAllMessages(const QVariantMap &properties);
+    Q_NOREPLY void RedownloadMessage(const QVariantMap &properties);
     bool DestroyTextChannel(const QString &objectPath);
     bool ChangeRoomTitle(const QString &objectPath, const QString &title);
     Q_NOREPLY void InviteParticipants(const QString &objectPath, const QStringList &participants, const QString &message);

--- a/handler/texthandler.cpp
+++ b/handler/texthandler.cpp
@@ -138,7 +138,7 @@ void TextHandler::redownloadMessage(const QString &accountId, const QString &thr
 
     History::TextEvent textEvent = History::Manager::instance()->getSingleEvent(History::EventTypeText, accountId, threadId, eventId);
     if (textEvent.isNull()) {
-      qWarning() << "No message found under accountId: " << accountId << ", threadId: " << threadId << ", eventId: " << eventId;
+      qWarning() << "No message for re-download found under accountId: " << accountId << ", threadId: " << threadId << ", eventId: " << eventId;
       return;
     }
 
@@ -153,9 +153,9 @@ void TextHandler::redownloadMessage(const QString &accountId, const QString &thr
     qDebug() << "jezek - History::MessageStatusDraft: " << History::MessageStatusDraft;
     qDebug() << "jezek - message status: " << textEvent.messageStatus();
 
-    // Only re-download unknown messages.
-    //TODO:jezek Make ti only temporary failed & incoming.
-    if (textEvent.messageStatus() != History::MessageStatusUnknown) {
+    //TODO:jezek Check if message is incoming (to == self).
+    // Only re-download temporarily failed messages.
+    if (textEvent.messageStatus() != History::MessageStatusTemporarilyFailed) {
       qWarning() << "Trying to re-download message with wrong status: " << textEvent.messageStatus();
       return;
     }
@@ -165,7 +165,7 @@ void TextHandler::redownloadMessage(const QString &accountId, const QString &thr
     History::Events events;
     events.append(textEvent);
     if (!History::Manager::instance()->writeEvents(events)) {
-      qWarning() << "Failed to save the new message status!";
+      qWarning() << "Failed to save the re-downloaded message pending status!";
     }
 
     QDBusMessage request;

--- a/handler/texthandler.cpp
+++ b/handler/texthandler.cpp
@@ -120,7 +120,6 @@ void TextHandler::acknowledgeMessages(const QVariantList &messages)
 
 void TextHandler::acknowledgeAllMessages(const QVariantMap &properties)
 {
-    qDebug() << "jezek - TextHandler::acknowledgeAllMessages";
     QList<Tp::TextChannelPtr> channels = existingChannels(properties["accountId"].toString(), properties);
     if (channels.isEmpty()) {
         return;
@@ -133,8 +132,6 @@ void TextHandler::acknowledgeAllMessages(const QVariantMap &properties)
 
 void TextHandler::redownloadMessage(const QString &accountId, const QString &threadId, const QString &eventId)
 {
-    qDebug() << "jezek - TextHandler::redownloadMessage";
-    qDebug() << "jezek - accountId: " << accountId << ", threadId: " << threadId << ", eventId: " << eventId;
 
     History::TextEvent textEvent = History::Manager::instance()->getSingleEvent(History::EventTypeText, accountId, threadId, eventId);
     if (textEvent.isNull()) {
@@ -142,18 +139,7 @@ void TextHandler::redownloadMessage(const QString &accountId, const QString &thr
       return;
     }
 
-    qDebug() << "jezek - History::MessageStatusUnknown: " << History::MessageStatusUnknown;
-    qDebug() << "jezek - History::MessageStatusDelivered: " << History::MessageStatusDelivered;
-    qDebug() << "jezek - History::MessageStatusTemporarilyFailed: " << History::MessageStatusTemporarilyFailed;
-    qDebug() << "jezek - History::MessageStatusPermanentlyFailed: " << History::MessageStatusPermanentlyFailed;
-    qDebug() << "jezek - History::MessageStatusAccepted: " << History::MessageStatusAccepted;
-    qDebug() << "jezek - History::MessageStatusRead: " << History::MessageStatusRead;
-    qDebug() << "jezek - History::MessageStatusDeleted: " << History::MessageStatusDeleted;
-    qDebug() << "jezek - History::MessageStatusPending: " << History::MessageStatusPending;
-    qDebug() << "jezek - History::MessageStatusDraft: " << History::MessageStatusDraft;
-    qDebug() << "jezek - message status: " << textEvent.messageStatus();
 
-    //TODO:jezek Check if message is incoming (to == self).
     // Only re-download temporarily failed messages.
     if (textEvent.messageStatus() != History::MessageStatusTemporarilyFailed) {
       qWarning() << "Trying to re-download message with wrong status: " << textEvent.messageStatus();
@@ -173,7 +159,6 @@ void TextHandler::redownloadMessage(const QString &accountId, const QString &thr
                                    eventId, "org.ofono.mms.Message",
                                    "Redownload");
     QDBusConnection::sessionBus().call(request);
-    qDebug() << "jezek - Sent Redownload method request to " << eventId;
 }
 
 bool TextHandler::destroyTextChannel(const QString &objectPath)

--- a/handler/texthandler.cpp
+++ b/handler/texthandler.cpp
@@ -32,6 +32,8 @@
 #include <TelepathyQt/ContactManager>
 #include <TelepathyQt/PendingContacts>
 #include <TelepathyQt/PendingChannelRequest>
+#include <QDBusMessage>
+#include <QDBusConnection>
 
 TextHandler::TextHandler(QObject *parent)
 : QObject(parent)
@@ -116,6 +118,7 @@ void TextHandler::acknowledgeMessages(const QVariantList &messages)
 
 void TextHandler::acknowledgeAllMessages(const QVariantMap &properties)
 {
+    qDebug() << "jezek - TextHandler::acknowledgeAllMessages";
     QList<Tp::TextChannelPtr> channels = existingChannels(properties["accountId"].toString(), properties);
     if (channels.isEmpty()) {
         return;
@@ -124,6 +127,17 @@ void TextHandler::acknowledgeAllMessages(const QVariantMap &properties)
     Q_FOREACH(const Tp::TextChannelPtr &channel, channels) {
         channel->acknowledge(channel->messageQueue());
     }
+}
+
+void TextHandler::redownloadMessage(const QVariantMap &properties)
+{
+    qDebug() << "jezek - TextHandler::redownloadMessage";
+    QDBusMessage request;
+    request = QDBusMessage::createMethodCall("org.ofono.mms",
+                                   properties["messageId"].toString(), "org.ofono.mms.Message",
+                                   "Redownload");
+    QDBusConnection::sessionBus().call(request);
+    qDebug() << "TODO:jezek - sent Redownload method request to " << properties["messageId"].toString();
 }
 
 bool TextHandler::destroyTextChannel(const QString &objectPath)

--- a/handler/texthandler.h
+++ b/handler/texthandler.h
@@ -43,6 +43,7 @@ public Q_SLOTS:
     QString sendMessage(const QString &accountId, const QString &message, const AttachmentList &attachments, const QVariantMap &properties);
     void acknowledgeMessages(const QVariantList &messages);
     void acknowledgeAllMessages(const QVariantMap &properties);
+    void redownloadMessage(const QVariantMap &properties);
     bool destroyTextChannel(const QString &objectPath);
     bool changeRoomTitle(const QString &objectPath, const QString &title);
     void inviteParticipants(const QString &objectPath, const QStringList &participants, const QString &message);

--- a/handler/texthandler.h
+++ b/handler/texthandler.h
@@ -43,7 +43,7 @@ public Q_SLOTS:
     QString sendMessage(const QString &accountId, const QString &message, const AttachmentList &attachments, const QVariantMap &properties);
     void acknowledgeMessages(const QVariantList &messages);
     void acknowledgeAllMessages(const QVariantMap &properties);
-    void redownloadMessage(const QVariantMap &properties);
+    void redownloadMessage(const QString &accountId, const QString &threadId, const QString &eventId);
     bool destroyTextChannel(const QString &objectPath);
     bool changeRoomTitle(const QString &objectPath, const QString &title);
     void inviteParticipants(const QString &objectPath, const QStringList &participants, const QString &message);

--- a/indicator/textchannelobserver.cpp
+++ b/indicator/textchannelobserver.cpp
@@ -500,8 +500,8 @@ void TextChannelObserver::showNotificationForMessage(const Tp::TextChannelPtr ch
         } else if (attachmentCount > 0) {
             messageText = QString::fromUtf8(C::ngettext("Attachment: %1 file", "Attachments: %1 files", attachmentCount)).arg(attachmentCount);
         } else {
-            // TRANSLATORS : message displayed when any error occured while receiving a mms ( case when cellular-data is off, or any downloading issue). Note that mms is lost in that case
-            messageText = QString::fromUtf8(C::gettext("Oops, there has been an error with the MMS system and this message could not be retrieved. Please ensure Cellular Data is ON and MMS settings are correct, then ask the sender to try again."));
+            // TRANSLATORS : message displayed when any error occurred while receiving a MMS (case when cellular-data is off, or any downloading issue). Notify that there was a message, the user can find more about it in the messaging-app.
+            messageText = QString::fromUtf8(C::gettext("New MMS message"));
         }
     }
 

--- a/libtelephonyservice/chatmanager.cpp
+++ b/libtelephonyservice/chatmanager.cpp
@@ -32,8 +32,6 @@
 #include <TelepathyQt/ContactManager>
 #include <TelepathyQt/PendingContacts>
 #include <QDBusArgument>
-#include <QDBusMessage>
-#include <QDBusConnection>
 
 QDBusArgument &operator<<(QDBusArgument &argument, const AttachmentStruct &attachment)
 {
@@ -304,18 +302,14 @@ void ChatManager::acknowledgeAllMessages(const QVariantMap &properties)
 }
 
 /**
- * Sends an asynchronious call through DBus to redownload a message identified by properties.
- *
- * Properties:
- * accountId: string - On which account the redownload will happen.
- * messageId: string - Message identifier of message which should be redownloaded.
- * TODO:jezek - don't use properties, use specified vars.
+ * Sends an asynchronous call through DBus to re-download a message identified by properties.
+ * Parameters accountId, threadId, eventId uniquely identify the message, which shall be redownloaded.
  */
-void ChatManager::redownloadMessage(const QVariantMap &properties)
+void ChatManager::redownloadMessage(const QString &accountId, const QString &threadId, const QString &eventId)
 {
     qDebug() << "jezek - ChatManager::redownloadMessage";
     QDBusInterface *phoneAppHandler = TelepathyHelper::instance()->handlerInterface();
-    phoneAppHandler->asyncCall("RedownloadMessage", convertPropertiesForDBus(properties));
+    phoneAppHandler->asyncCall("RedownloadMessage", accountId, threadId, eventId);
 }
 
 void ChatManager::onAckTimerTriggered()

--- a/libtelephonyservice/chatmanager.cpp
+++ b/libtelephonyservice/chatmanager.cpp
@@ -32,6 +32,8 @@
 #include <TelepathyQt/ContactManager>
 #include <TelepathyQt/PendingContacts>
 #include <QDBusArgument>
+#include <QDBusMessage>
+#include <QDBusConnection>
 
 QDBusArgument &operator<<(QDBusArgument &argument, const AttachmentStruct &attachment)
 {
@@ -296,8 +298,24 @@ void ChatManager::acknowledgeMessage(const QVariantMap &properties)
 
 void ChatManager::acknowledgeAllMessages(const QVariantMap &properties)
 {
+    qDebug() << "jezek - ChatManager::acknowledgeAllMessages";
     QDBusInterface *phoneAppHandler = TelepathyHelper::instance()->handlerInterface();
     phoneAppHandler->asyncCall("AcknowledgeAllMessages", convertPropertiesForDBus(properties));
+}
+
+/**
+ * Sends an asynchronious call through DBus to redownload a message identified by properties.
+ *
+ * Properties:
+ * accountId: string - On which account the redownload will happen.
+ * messageId: string - Message identifier of message which should be redownloaded.
+ * TODO:jezek - don't use properties, use specified vars.
+ */
+void ChatManager::redownloadMessage(const QVariantMap &properties)
+{
+    qDebug() << "jezek - ChatManager::redownloadMessage";
+    QDBusInterface *phoneAppHandler = TelepathyHelper::instance()->handlerInterface();
+    phoneAppHandler->asyncCall("RedownloadMessage", convertPropertiesForDBus(properties));
 }
 
 void ChatManager::onAckTimerTriggered()

--- a/libtelephonyservice/chatmanager.cpp
+++ b/libtelephonyservice/chatmanager.cpp
@@ -296,7 +296,6 @@ void ChatManager::acknowledgeMessage(const QVariantMap &properties)
 
 void ChatManager::acknowledgeAllMessages(const QVariantMap &properties)
 {
-    qDebug() << "jezek - ChatManager::acknowledgeAllMessages";
     QDBusInterface *phoneAppHandler = TelepathyHelper::instance()->handlerInterface();
     phoneAppHandler->asyncCall("AcknowledgeAllMessages", convertPropertiesForDBus(properties));
 }
@@ -307,7 +306,6 @@ void ChatManager::acknowledgeAllMessages(const QVariantMap &properties)
  */
 void ChatManager::redownloadMessage(const QString &accountId, const QString &threadId, const QString &eventId)
 {
-    qDebug() << "jezek - ChatManager::redownloadMessage";
     QDBusInterface *phoneAppHandler = TelepathyHelper::instance()->handlerInterface();
     phoneAppHandler->asyncCall("RedownloadMessage", accountId, threadId, eventId);
 }

--- a/libtelephonyservice/chatmanager.h
+++ b/libtelephonyservice/chatmanager.h
@@ -54,7 +54,7 @@ public Q_SLOTS:
 
     void acknowledgeMessage(const QVariantMap &properties);
     void acknowledgeAllMessages(const QVariantMap &properties);
-    void redownloadMessage(const QVariantMap &properties);
+    void redownloadMessage(const QString &accountId, const QString &threadId, const QString &eventId);
     void leaveRooms(const QString &accountId, const QString &message);
     void leaveRoom(const QVariantMap &properties, const QString &message);
 

--- a/libtelephonyservice/chatmanager.h
+++ b/libtelephonyservice/chatmanager.h
@@ -54,6 +54,7 @@ public Q_SLOTS:
 
     void acknowledgeMessage(const QVariantMap &properties);
     void acknowledgeAllMessages(const QVariantMap &properties);
+    void redownloadMessage(const QVariantMap &properties);
     void leaveRooms(const QString &accountId, const QString &message);
     void leaveRoom(const QVariantMap &properties, const QString &message);
 

--- a/tests/handler/HandlerTest.cpp
+++ b/tests/handler/HandlerTest.cpp
@@ -482,6 +482,8 @@ void HandlerTest::testAcknowledgeAllMessages()
     TRY_COMPARE(messageReadSpy.count(), messageCount);
 }
 
+//TODO:jezek - testRedownloadMessage, documentation, changelogs, etc...
+
 void HandlerTest::testActiveCallIndicator()
 {
     // start by making sure the property is false by default

--- a/tests/handler/HandlerTest.cpp
+++ b/tests/handler/HandlerTest.cpp
@@ -482,8 +482,6 @@ void HandlerTest::testAcknowledgeAllMessages()
     TRY_COMPARE(messageReadSpy.count(), messageCount);
 }
 
-//TODO:jezek - testRedownloadMessage, documentation, changelogs, etc...
-
 void HandlerTest::testActiveCallIndicator()
 {
     // start by making sure the property is false by default


### PR DESCRIPTION
Adds redownloadMessage function to chatManager, which signals a method on dbus.

Note: This PR is accompanied by ubports/nuntium#8, ubports/telepathy-ofono#20, [gitlab/ubports/core/history-service#8](https://gitlab.com/ubports/core/history-service/-/merge_requests/8) and ubports/messaging-app#260

Note: After building and deploying to phone with crossbuilder phone needs to be restarted for changes to apply.