### PR TITLE
Prevent switching to loudspeaker too early, when disconnect tones are still played

### DIFF
--- a/handler/audioroutemanager.cpp
+++ b/handler/audioroutemanager.cpp
@@ -43,7 +43,7 @@ static void enable_normal()
         QPulseAudioEngine::instance()->setCallMode(CallEnded, AudioModeWiredOrSpeaker);
         timer->deleteLater();
     });
-    timer->start(2000);
+    timer->start(2200);
 #endif
 }
 

--- a/handler/callhandler.cpp
+++ b/handler/callhandler.cpp
@@ -33,6 +33,8 @@
 #include <TelepathyQt/PendingChannelRequest>
 #include <TelepathyQt/PendingVariant>
 #include <memory>
+#include <thread>
+#include <chrono>
 
 #define TELEPATHY_MUTE_IFACE "org.freedesktop.Telepathy.Call1.Interface.Mute"
 #define DBUS_PROPERTIES_IFACE "org.freedesktop.DBus.Properties"
@@ -353,6 +355,7 @@ void CallHandler::onCallChannelInvalidated()
     ToneGenerator::instance()->stopTone();
     if (mCallChannels.isEmpty() && !mHangupRequested) {
         ToneGenerator::instance()->playCallEndedTone();
+		std::this_thread::sleep_for(std::chrono::milliseconds(2200));
     }
     mHangupRequested = false;
 }

--- a/handler/callhandler.cpp
+++ b/handler/callhandler.cpp
@@ -33,8 +33,6 @@
 #include <TelepathyQt/PendingChannelRequest>
 #include <TelepathyQt/PendingVariant>
 #include <memory>
-#include <thread>
-#include <chrono>
 
 #define TELEPATHY_MUTE_IFACE "org.freedesktop.Telepathy.Call1.Interface.Mute"
 #define DBUS_PROPERTIES_IFACE "org.freedesktop.DBus.Properties"
@@ -355,7 +353,6 @@ void CallHandler::onCallChannelInvalidated()
     ToneGenerator::instance()->stopTone();
     if (mCallChannels.isEmpty() && !mHangupRequested) {
         ToneGenerator::instance()->playCallEndedTone();
-		std::this_thread::sleep_for(std::chrono::milliseconds(2200));
     }
     mHangupRequested = false;
 }


### PR DESCRIPTION
This will fix https://github.com/ubports/ubuntu-touch/issues/49 and similar reports... I want a grandfather price for that finding :)