### PR TITLE
PhoneUtils: Add method to get the country prefix from a locale string

### DIFF
--- a/Ubuntu/Telephony/PhoneNumber/phoneutils.cpp
+++ b/Ubuntu/Telephony/PhoneNumber/phoneutils.cpp
@@ -42,6 +42,14 @@ QString PhoneUtils::defaultRegion() const
     return locale.split("_").last();
 }
 
+int PhoneUtils::getCountryCodePrefix(const QString &country) const
+{
+    if (country.isEmpty()) {
+        country = defaultRegion();
+    }
+    return i18n::phonenumbers::PhoneNumberUtil::GetInstance()->GetCountryCodeForRegion(country.toStdString());
+}
+
 QString PhoneUtils::format(const QString &phoneNumber, const QString &defaultRegion,  PhoneUtils::PhoneNumberFormat format)
 {
     std::string formattedNumber;

--- a/Ubuntu/Telephony/PhoneNumber/phoneutils.cpp
+++ b/Ubuntu/Telephony/PhoneNumber/phoneutils.cpp
@@ -42,12 +42,14 @@ QString PhoneUtils::defaultRegion() const
     return locale.split("_").last();
 }
 
-int PhoneUtils::getCountryCodePrefix(const QString &country) const
+/*!
+  From a locale code, e.g FR, retrieve the phone prefix: "33"
+  If regionCode is empty, fallback to US
+*/
+int PhoneUtils::getCountryCodePrefix(const QString &regionCode) const
 {
-    if (country.isEmpty()) {
-        country = defaultRegion();
-    }
-    return i18n::phonenumbers::PhoneNumberUtil::GetInstance()->GetCountryCodeForRegion(country.toStdString());
+    QString locale = regionCode.isEmpty() ? QString("US") : regionCode;
+    return i18n::phonenumbers::PhoneNumberUtil::GetInstance()->GetCountryCodeForRegion(locale.toStdString());
 }
 
 QString PhoneUtils::format(const QString &phoneNumber, const QString &defaultRegion,  PhoneUtils::PhoneNumberFormat format)

--- a/Ubuntu/Telephony/PhoneNumber/phoneutils.h
+++ b/Ubuntu/Telephony/PhoneNumber/phoneutils.h
@@ -47,6 +47,8 @@ public:
 
     Q_INVOKABLE QString format(const QString &phoneNumber, const QString &defaultRegion = QString(), PhoneNumberFormat format = Auto);
 
+    Q_INVOKABLE int getCountryCodePrefix(const QString &country);
+
     virtual bool event(QEvent *event);
 
 Q_SIGNALS:

--- a/Ubuntu/Telephony/PhoneNumber/phoneutils.h
+++ b/Ubuntu/Telephony/PhoneNumber/phoneutils.h
@@ -47,7 +47,7 @@ public:
 
     Q_INVOKABLE QString format(const QString &phoneNumber, const QString &defaultRegion = QString(), PhoneNumberFormat format = Auto);
 
-    Q_INVOKABLE int getCountryCodePrefix(const QString &country);
+    Q_INVOKABLE int getCountryCodePrefix(const QString &regionCode) const;
 
     virtual bool event(QEvent *event);
 

--- a/tests/Ubuntu.Telephony/tst_PhoneNumberPhoneUtils.qml
+++ b/tests/Ubuntu.Telephony/tst_PhoneNumberPhoneUtils.qml
@@ -83,5 +83,18 @@ TestCase {
         var actualMatches = PhoneNumber.PhoneUtils.matchInText(data.text, "US")
         compareMatches(actualMatches, data.expectedMatches)
     }
+
+
+    function test_getCountryPrefix() {
+        var resultFakeLocale = PhoneNumber.PhoneUtils.getCountryCodePrefix("fake");
+        compare(resultFakeLocale, 0)
+
+        var resultNoLocale = PhoneNumber.PhoneUtils.getCountryCodePrefix(null);
+        compare(resultNoLocale, 1)
+
+        var resultLocale = PhoneNumber.PhoneUtils.getCountryCodePrefix("FR");
+        compare(resultLocale, 33)
+
+    }
 }
 


### PR DESCRIPTION
this is needed with DialPadSearch https://github.com/ubports/dialer-app/pull/158, we need to guess the locale phone prefix.
e.g in QML client: PhoneUtils.getCountryCodePrefix("FR"), will return "33"