### PR TITLE
Do not create a useless account0 in setup of ofono when accounts are created elsewhere

### DIFF
--- a/tools/ofono-setup
+++ b/tools/ofono-setup
@@ -85,6 +85,7 @@ MODEM_COUNT=0
 # Those accounts are created from there
 if [ "$(getprop ro.build.version.sdk 99)" -ge "27" ]; then
     echo "Android SDK version 27 or greater detected. No modem detection will be made."
+    exit 0
 fi
 
 # check if there is at least one modem

--- a/tools/ofono-setup
+++ b/tools/ofono-setup
@@ -81,6 +81,12 @@ EXISTING_OFONO_ACCOUNTS=$(get_telepathy_ofono_accounts)
 EXISTING_OFONO_ACCOUNTS_COUNT=$(get_telepathy_ofono_accounts | wc -l)
 MODEM_COUNT=0
 
+# Do not run the legacy modem detection if newer ofono with binder interface is being used
+# Those accounts are created from there
+if [ "$(getprop ro.build.version.sdk 99)" -ge "27" ]; then
+    echo "Android SDK version 27 or greater detected. No modem detection will be made."
+fi
+
 # check if there is at least one modem
 if [ "$(getprop rild.libpath '')" != "" ]; then
     MODEM_COUNT=$(getprop ril.num_slots 1)

--- a/tools/ofono-setup
+++ b/tools/ofono-setup
@@ -85,8 +85,12 @@ MODEM_COUNT=0
 # Those accounts are created from there
 if [ "$(getprop ro.build.version.sdk 99)" -ge "27" ]; then
     echo "Android SDK version 27 or greater detected. No modem detection will be made."
-    # Remove an eventual account that got here before the fix
-    mc-tool remove ofono/ofono/account0
+    for account in $EXISTING_OFONO_ACCOUNTS; do
+        # Remove an eventual account that got here before the fix
+        if [ -z "${account##*account*}" ]; then
+           mc-tool remove $account 2>&1 > /dev/null
+        fi
+    done
     exit 0
 fi
 

--- a/tools/ofono-setup
+++ b/tools/ofono-setup
@@ -85,6 +85,8 @@ MODEM_COUNT=0
 # Those accounts are created from there
 if [ "$(getprop ro.build.version.sdk 99)" -ge "27" ]; then
     echo "Android SDK version 27 or greater detected. No modem detection will be made."
+    # Remove an eventual account that got here before the fix
+    mc-tool remove ofono/ofono/account0
     exit 0
 fi
 


### PR DESCRIPTION
This was a long story:

- some H9 and a H10 device had really chaotic call signalling all over the place. duplicate calls, frozen dialler, not being able to hang up etc. etc.
- Randomly I came across DBus logs showing clearly that telepathy signalled 2 calls __from the same ofono modem__ which is basically impossible.
- Until I found ofono-setup script:
- The script tries to guess from a special property ril.num_slots how many __legacy__ ril sockets are there and how many accounts need to be created. The unset variable would be taken as 1 slot always.
- we do not run the critical part now when SDKL level >=27 (or no SDK at all) is detected.