### PR TITLE
lib: use the new qtcontacts-sqlite backend

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -68,7 +68,7 @@ Architecture: any
 Multi-Arch: same
 Pre-Depends: dpkg (>= 1.15.6~)
 Depends: gsettings-ubuntu-schemas,
-         qtcontact5-galera[!s390x],
+         qtcontacts-sqlite-qt5-extension,
          telephony-service (>= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},

--- a/libtelephonyservice/contactutils.h
+++ b/libtelephonyservice/contactutils.h
@@ -32,7 +32,7 @@ QTCONTACTS_USE_NAMESPACE
 
 namespace ContactUtils
 {
-    QContactManager *sharedManager(const QString &engine = "galera");
+    QContactManager *sharedManager(const QString &engine = "org.nemomobile.contacts.sqlite");
     QString formatContactName(const QContact &contact);
 }
 


### PR DESCRIPTION
This PR is part of the efforts to switch to the new qtcontacts-sqlite backend: ubports/ubuntu-touch#997