### PR TITLE
Redownload dbus result

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+telephony-service (0.5+0ubports1) xenial; urgency=medium
+
+  * Make it possible to ask nuntium for MMS message re-download.
+
+ -- jEzEk <jezek@chicki.sk>  Thu, 06 Jan 2022 18:17:43 +0200
+
 telephony-service (0.4+0ubports3) xenial; urgency=medium
 
   * mms lost or on download error: notify user

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-telephony-service (0.5+0ubports1) xenial; urgency=medium
+telephony-service (0.4+0ubports5) xenial; urgency=medium
+
+  * Revert status on dbus reply error on message redownload
+
+ -- jEzEk <jezek@chicki.sk>  Fri, 21 Jan 2022 18:28:35 +0200
+
+telephony-service (0.4+0ubports4) xenial; urgency=medium
 
   * Make it possible to ask nuntium for MMS message re-download.
 


### PR DESCRIPTION
This PR tries to fix the some of the occasional endless wheel spinning after re-download, reported in previous [PR comment](https://github.com/ubports/nuntium/pull/8#issuecomment-869726364) and [forum](https://forums.ubports.com/topic/6510/mms-users-call-for-testing/60?_=1642870667716).

It also updates debian/changelog with changes in my previous PR #20 .