### PR TITLE
prevent deadlock when several ContactWatcher instance is being removed.

### DIFF
--- a/libtelephonyservice/contactwatcher.cpp
+++ b/libtelephonyservice/contactwatcher.cpp
@@ -58,7 +58,7 @@ ContactWatcher::~ContactWatcher()
 {
     if (mRequest) {
         mRequest->cancel();
-        delete mRequest;
+        mRequest->deleteLater();
     }
 }
 

--- a/libtelephonyservice/contactwatcher.cpp
+++ b/libtelephonyservice/contactwatcher.cpp
@@ -56,6 +56,9 @@ ContactWatcher::ContactWatcher(QObject *parent) :
 
 ContactWatcher::~ContactWatcher()
 {
+    // prevent deadlock while ContactWatcher being removed
+    // https://github.com/ubports/messaging-app/issues/338
+    ContactUtils::sharedManager()->disconnect(this);
     if (mRequest) {
         mRequest->cancel();
         mRequest->deleteLater();


### PR DESCRIPTION
fixes https://github.com/ubports/messaging-app/issues/338